### PR TITLE
Add Hibernate DAO Layer with Liquibase Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,67 +4,80 @@
 
 #### --> Task 1 --> DAO Layer (Data Access Object) with Hibernate
 
-# DAO Layer with Hibernate
+# Hibernate DAO Layer with Liquibase Migration
 
-This project demonstrates the implementation of a DAO layer using Hibernate with Spring Boot. It includes an example of a `Person` entity and an `Order` entity with a one-to-many relationship. The project also features a controller to fetch persons based on their city of living.
+This project demonstrates the implementation of a DAO layer using Hibernate and Liquibase for database migrations in a Spring Boot application. It includes entities representing `Person` and `Order`, and demonstrates the use of one-to-many and many-to-one relationships.
 
 ## Project Structure
 
-- **Entity Classes**:
-  - `Person`: Represents a person with fields such as name, surname, age, phone number, and city of living.
-  - `Order`: Represents an order with fields such as date, amount, and payment type. Each order is associated with a person.
+- `entity` package: Contains the `Person` and `Order` entity classes.
+- `dao` package: Contains the DAO interfaces and implementations.
+- `service` package: Contains the service classes.
+- `controller` package: Contains the controller classes.
+- `resources/db/changelog`: Contains Liquibase changelog files for database migrations.
 
-- **Repository**:
-  - `PersonDAO`: Interface defining the method to fetch persons by city.
-  - `PersonDAOImpl`: Implementation of the `PersonDAO` interface using Hibernate's `EntityManager`.
+## Setup and Run
 
-- **Service**:
-  - `PersonService`: Service layer to handle business logic and interact with the `PersonDAO`.
+1. **Clone the Repository**
 
-- **Controller**:
-  - `PersonController`: REST controller to handle HTTP requests and return responses.
-
-## Dependencies
-
-The project uses the following dependencies:
-- Spring Boot Starter Data JPA
-- Spring Boot Starter Web
-- Hibernate
-- Lombok
-
-## Getting Started
-
-### Prerequisites
-
-Ensure you have the following installed:
-- Java 17
-- Maven
-- PostgreSQL
-
-### Setting Up the Database
-
-1. Create a PostgreSQL database named `orm_hibernate_hw`.
-2. Update the `application.properties` file with your database credentials.
-
-### Running the Application
-
-1. Clone the repository.
-2. Navigate to the project directory.
-3. Run the application using Maven:
 ```
-   mvn spring-boot:run
+   git clone <repository-url>
+   cd <repository-directory>
+```
+
+2. Create Database
+
+Ensure you have a PostgreSQL database running and create a new database for the project.
+```
+CREATE DATABASE yourdatabase;
+```
+
+3. Configure Application Properties
+
+Update the src/main/resources/application.properties file with your database credentials.
+```
+spring.datasource.url=jdbc:postgresql://localhost:5432/yourdatabase
+spring.datasource.username=yourusername
+spring.datasource.password=yourpassword
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
+```
+
+4. Build and Run the Application
+```
+mvn clean install
+mvn spring-boot:run
+```
+
+5. Access the Application
+```
+The application will be accessible at http://localhost:8080.
 ```
 
 ## API Endpoints
-### Fetch Persons by City
-* URL: /persons/by-city
-* Method: GET
-* Query Parameters:
-  * city: The city of living of the persons to be fetched.
-* Response: A list of persons living in the specified city, along with their associated orders.
 
-## Example:
+### Get Persons by City
 ```
-curl -X GET "http://localhost:8080/persons/by-city?city=city_name"
+GET /persons/by-city?city={city}
 ```
 
+This endpoint retrieves a list of persons living in the specified city.
+
+## Database Migrations
+The project uses Liquibase for database migrations. 
+The changelog files are located in the src/main/resources/db/changelog directory.
+
+## Changelog Files
+* db.changelog-master.yaml: The main changelog file that includes all individual changelog files.
+* V0001__create_schema.sql: Creates the database schema.
+* V0002__create_table_person.sql: Creates the person table.
+* V0003__create_table_orders.sql: Creates the orders table.
+* V0004__alter_table_orders.sql: Alter the orders table.
+* V0005__insert_into_person.sql: Insert into the person table.
+* V0006_insert_into_orders.sql: Insert into the orders table.
+
+## Technologies Used
+* Spring Boot
+* Hibernate
+* Liquibase
+* PostgreSQL
+* Maven

--- a/README.md
+++ b/README.md
@@ -6,50 +6,65 @@
 
 # DAO Layer with Hibernate
 
-## Description
+This project demonstrates the implementation of a DAO layer using Hibernate with Spring Boot. It includes an example of a `Person` entity and an `Order` entity with a one-to-many relationship. The project also features a controller to fetch persons based on their city of living.
 
-This project is a Spring Boot application that demonstrates the use of the Data Access Object (DAO) pattern with Hibernate. It includes functionalities to interact with a database of persons, specifically allowing retrieval of persons based on their city of living.
+## Project Structure
 
-## Prerequisites
+- **Entity Classes**:
+  - `Person`: Represents a person with fields such as name, surname, age, phone number, and city of living.
+  - `Order`: Represents an order with fields such as date, amount, and payment type. Each order is associated with a person.
 
-- Java 17 or higher
-- Maven 3.6.3 or higher
-- PostgreSQL or another relational database
+- **Repository**:
+  - `PersonDAO`: Interface defining the method to fetch persons by city.
+  - `PersonDAOImpl`: Implementation of the `PersonDAO` interface using Hibernate's `EntityManager`.
+
+- **Service**:
+  - `PersonService`: Service layer to handle business logic and interact with the `PersonDAO`.
+
+- **Controller**:
+  - `PersonController`: REST controller to handle HTTP requests and return responses.
+
+## Dependencies
+
+The project uses the following dependencies:
+- Spring Boot Starter Data JPA
+- Spring Boot Starter Web
+- Hibernate
+- Lombok
 
 ## Getting Started
 
-### Clone the Repository
+### Prerequisites
 
+Ensure you have the following installed:
+- Java 17
+- Maven
+- PostgreSQL
+
+### Setting Up the Database
+
+1. Create a PostgreSQL database named `orm_hibernate_hw`.
+2. Update the `application.properties` file with your database credentials.
+
+### Running the Application
+
+1. Clone the repository.
+2. Navigate to the project directory.
+3. Run the application using Maven:
 ```
-git clone <repository-url>
-cd <repository-directory>
+   mvn spring-boot:run
 ```
-
-## Set Up the Database
-Create a PostgreSQL database named.
-Update the application.properties file with your PostgreSQL username and password.
-
-## Build and Run the Application
-- mvn clean install
-- mvn spring-boot:run
-
-
-## Application Structure
-- Entity: The Person entity represents the persons table in the database.
-- DAO: The PersonDAOImpl class provides methods to interact with the database.
-- Service: The PersonService class contains business logic and calls the DAO methods.
-- Controller: The PersonController class handles HTTP requests and responses.
 
 ## API Endpoints
-- GET /persons/by-city: Retrieves a list of persons based on the city of living.
-  - Query Parameters:
-      - city (String): The name of the city.
+### Fetch Persons by City
+* URL: /persons/by-city
+* Method: GET
+* Query Parameters:
+  * city: The city of living of the persons to be fetched.
+* Response: A list of persons living in the specified city, along with their associated orders.
 
-## Example Request
-curl -X GET "http://localhost:8080/persons/by-city?city=Moscow"
+## Example:
+```
+curl -X GET "http://localhost:8080/persons/by-city?city=city_name"
+```
 
-## Dependencies
-- Spring Boot Starter Data JPA
-- Spring Boot Starter Web
-- PostgreSQL JDBC Driver
-- Lombok

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>4.28.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/agan/layerdao_hibernate/dao/PersonDAOImpl.java
+++ b/src/main/java/com/agan/layerdao_hibernate/dao/PersonDAOImpl.java
@@ -16,18 +16,9 @@ public class PersonDAOImpl implements PersonDAO {
 
     @Transactional
     public List<Person> getPersonsByCity(String city) {
-//        String query = "SELECT p FROM Person p WHERE p.cityOfLiving = :cityInJPQL";
-
-//        String query = "FROM orm_hibernate_hw.person JOIN orm_hibernate_hw.orders" +
-//                       "ON person.age = orders.customer_age" +
-//                       "AND person.name = orders.customer_name" +
-//                       "AND person.surname = orders.customer_surname" +
-//                       "WHERE city_of_living = :city";
-
 
         String query = "SELECT o FROM Order o JOIN o.person p " +
                        "WHERE p.cityOfLiving = :cityInJPQL";
-
 
         List<Person> persons;
 

--- a/src/main/java/com/agan/layerdao_hibernate/dao/PersonDAOImpl.java
+++ b/src/main/java/com/agan/layerdao_hibernate/dao/PersonDAOImpl.java
@@ -16,7 +16,19 @@ public class PersonDAOImpl implements PersonDAO {
 
     @Transactional
     public List<Person> getPersonsByCity(String city) {
-        String query = "SELECT p FROM Person p WHERE p.cityOfLiving = :cityInJPQL";
+//        String query = "SELECT p FROM Person p WHERE p.cityOfLiving = :cityInJPQL";
+
+//        String query = "FROM orm_hibernate_hw.person JOIN orm_hibernate_hw.orders" +
+//                       "ON person.age = orders.customer_age" +
+//                       "AND person.name = orders.customer_name" +
+//                       "AND person.surname = orders.customer_surname" +
+//                       "WHERE city_of_living = :city";
+
+
+        String query = "SELECT o FROM Order o JOIN o.person p " +
+                       "WHERE p.cityOfLiving = :cityInJPQL";
+
+
         List<Person> persons;
 
         try {

--- a/src/main/java/com/agan/layerdao_hibernate/entity/Order.java
+++ b/src/main/java/com/agan/layerdao_hibernate/entity/Order.java
@@ -1,0 +1,38 @@
+package com.agan.layerdao_hibernate.entity;
+
+import com.agan.layerdao_hibernate.entity.enums.PaymentType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Table(schema = "orm_hibernate_hw", name = "orders")
+@Entity
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "customer_id", nullable = false)
+    private Person person;
+
+    @Id
+    @Column(name = "date")
+    private Date date;
+
+    @Id
+    @Column(name = "amount")
+    private double amount;
+
+    @Column(name = "payment_type")
+    private PaymentType paymentType;
+
+}

--- a/src/main/java/com/agan/layerdao_hibernate/entity/Order.java
+++ b/src/main/java/com/agan/layerdao_hibernate/entity/Order.java
@@ -1,6 +1,5 @@
 package com.agan.layerdao_hibernate.entity;
 
-import com.agan.layerdao_hibernate.entity.enums.PaymentType;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/agan/layerdao_hibernate/entity/Order.java
+++ b/src/main/java/com/agan/layerdao_hibernate/entity/Order.java
@@ -1,6 +1,7 @@
 package com.agan.layerdao_hibernate.entity;
 
 import com.agan.layerdao_hibernate.entity.enums.PaymentType;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,18 +22,22 @@ public class Order {
     private long id;
 
     @ManyToOne
-    @JoinColumn(name = "customer_id", nullable = false)
+//    @JoinColumn(name = "customer_id", nullable = false)
+    @JoinColumns({
+            @JoinColumn(name = "customer_name", referencedColumnName = "name"),
+            @JoinColumn(name = "customer_surname", referencedColumnName = "surname"),
+            @JoinColumn(name = "customer_age", referencedColumnName = "age")
+    })
+    @JsonBackReference
     private Person person;
 
-    @Id
     @Column(name = "date")
     private Date date;
 
-    @Id
     @Column(name = "amount")
     private double amount;
 
     @Column(name = "payment_type")
-    private PaymentType paymentType;
+    private String paymentType;
 
 }

--- a/src/main/java/com/agan/layerdao_hibernate/entity/Person.java
+++ b/src/main/java/com/agan/layerdao_hibernate/entity/Person.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -36,6 +38,9 @@ public class Person {
 
     @Column(name = "city_of_living")
     private String cityOfLiving;
+
+    @OneToMany(mappedBy = "person", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Order> orders;
 
 
 }

--- a/src/main/java/com/agan/layerdao_hibernate/entity/Person.java
+++ b/src/main/java/com/agan/layerdao_hibernate/entity/Person.java
@@ -1,5 +1,6 @@
 package com.agan.layerdao_hibernate.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,6 +41,7 @@ public class Person {
     private String cityOfLiving;
 
     @OneToMany(mappedBy = "person", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private List<Order> orders;
 
 

--- a/src/main/java/com/agan/layerdao_hibernate/entity/enums/PaymentType.java
+++ b/src/main/java/com/agan/layerdao_hibernate/entity/enums/PaymentType.java
@@ -1,0 +1,6 @@
+package com.agan.layerdao_hibernate.entity.enums;
+
+public enum PaymentType {
+    CASH,
+    CREDIT_CARD
+}

--- a/src/main/java/com/agan/layerdao_hibernate/service/PersonService.java
+++ b/src/main/java/com/agan/layerdao_hibernate/service/PersonService.java
@@ -1,7 +1,7 @@
 package com.agan.layerdao_hibernate.service;
 
-import com.agan.layerdao_hibernate.entity.Person;
 import com.agan.layerdao_hibernate.dao.PersonDAOImpl;
+import com.agan.layerdao_hibernate.entity.Person;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.stereotype.Service;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ spring.jpa.show-sql=true
 
 spring.main.web-application-type=servlet
 
+spring.liquibase.enabled=true
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
+spring.liquibase.clear-checksums=true

--- a/src/main/resources/db/changelog/changeset/V0001__create_schema_orm_hibernate_hw.sql
+++ b/src/main/resources/db/changelog/changeset/V0001__create_schema_orm_hibernate_hw.sql
@@ -1,0 +1,1 @@
+create schema orm_hibernate_hw;

--- a/src/main/resources/db/changelog/changeset/V0002__create_table_person.sql
+++ b/src/main/resources/db/changelog/changeset/V0002__create_table_person.sql
@@ -1,0 +1,9 @@
+create table orm_hibernate_hw.person (
+id BIGSERIAL NOT NULL,
+name VARCHAR(255) NOT NULL,
+surname VARCHAR(255) NOT NULL,
+age INT NOT NULL,
+phone_number VARCHAR(20) NOT NULL,
+city_of_living VARCHAR(100),
+CONSTRAINT person_pkey PRIMARY KEY (name, surname, age)
+);

--- a/src/main/resources/db/changelog/changeset/V0003__create_table_orders.sql
+++ b/src/main/resources/db/changelog/changeset/V0003__create_table_orders.sql
@@ -1,0 +1,6 @@
+create table orm_hibernate_hw.orders (
+    id BIGSERIAL PRIMARY KEY NOT NULL,
+    date DATE NOT NULL,
+    amount DOUBLE PRECISION NOT NULL,
+    payment_type VARCHAR(255)
+);

--- a/src/main/resources/db/changelog/changeset/V0004__alter_table_orders.sql
+++ b/src/main/resources/db/changelog/changeset/V0004__alter_table_orders.sql
@@ -1,0 +1,3 @@
+ALTER TABLE orm_hibernate_hw.orders ADD CONSTRAINT fk_customers
+    FOREIGN KEY (customer_name, customer_surname, customer_age)
+    REFERENCES orm_hibernate_hw.person (name, surname, age);

--- a/src/main/resources/db/changelog/changeset/V0005__insert_into_person.sql
+++ b/src/main/resources/db/changelog/changeset/V0005__insert_into_person.sql
@@ -1,0 +1,4 @@
+INSERT INTO orm_hibernate_hw.person (id, name, surname, age, city_of_living, phone_number)
+VALUES (1, 'Mihail', 'Rogozhin', 34, 'Moscow', '1234464');
+INSERT INTO orm_hibernate_hw.person (id, name, surname, age, city_of_living, phone_number)
+VALUES (2, 'Petr', 'Chernov', 28, 'Moscow', '7654321');

--- a/src/main/resources/db/changelog/changeset/V0006_insert_into_orders.sql
+++ b/src/main/resources/db/changelog/changeset/V0006_insert_into_orders.sql
@@ -1,0 +1,4 @@
+insert into orm_hibernate_hw.orders (id, amount, date, payment_type, customer_name, customer_surname, customer_age)
+values (1, 870.61, '2024-01-11', 'Credit Card', 'Petr', 'Chernov', 28);
+insert into orm_hibernate_hw.orders (id, amount, date, payment_type, customer_name, customer_surname, customer_age)
+values (2, 234.75, '2024-01-19', 'Cash', 'Petr', 'Chernov', 28);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - include:
+      file: db/changelog/changeset/V0001__create_schema_orm_hibernate_hw.sql
+  - include:
+      file: db/changelog/changeset/V0002__create_table_person.sql
+  - include:
+      file: db/changelog/changeset/V0003__create_table_orders.sql
+  - include:
+      file: db/changelog/changeset/V0004__alter_table_orders.sql
+  - include:
+      file: db/changelog/changeset/V0005__insert_into_person.sql
+  - include:
+      file: db/changelog/changeset/V0006_insert_into_orders.sql


### PR DESCRIPTION
This pull request adds a DAO layer implementation using Hibernate and Liquibase for database migrations in a Spring Boot application. It includes the following features:

- **Entities**:
  - `Person`: Represents a person entity with fields for name, surname, age, phone number, and city of living.
  - `Order`: Represents an order entity with fields for date, amount, payment type, and a many-to-one relationship with the `Person` entity.

- **DAO Layer**:
  - `PersonDAO`: Interface for person data access operations.
  - `PersonDAOImpl`: Implementation of `PersonDAO` using Hibernate.

- **Service Layer**:
  - `PersonService`: Provides services to interact with the DAO layer.

- **Controller Layer**:
  - `PersonController`: Exposes REST endpoints to interact with person data.

- **Liquibase Migrations**:
  - `db.changelog-master.yaml`: Main changelog file.
  - `V0001__create_schema.sql`: Creates the database schema.
  - `V0002__create_table_person.sql`: Creates the `person` table.
  - `V0003__create_table_orders.sql`: Creates the `orders` table.

## How to Test

1. **Clone the Repository**

   ```bash
   git clone <repository-url>
   cd <repository-directory>